### PR TITLE
Fix invalid HTML structure in RandomTip

### DIFF
--- a/frontend/src/components/features/tips/random-tip.tsx
+++ b/frontend/src/components/features/tips/random-tip.tsx
@@ -13,22 +13,24 @@ export function RandomTip() {
   }, []);
 
   return (
-    <p className="text-content">
+    <div className="text-content">
       <h4 className="font-bold">{t(I18nKey.TIPS$PROTIP)}:</h4>
-      {t(randomTip.key)}
-      {randomTip.link && (
-        <>
-          {" "}
-          <a
-            href={randomTip.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline text-content hover:text-content-2"
-          >
-            {t(I18nKey.TIPS$LEARN_MORE)}
-          </a>
-        </>
-      )}
-    </p>
+      <p>
+        {t(randomTip.key)}
+        {randomTip.link && (
+          <>
+            {" "}
+            <a
+              href={randomTip.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-content hover:text-content-2"
+            >
+              {t(I18nKey.TIPS$LEARN_MORE)}
+            </a>
+          </>
+        )}
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- restructure RandomTip to avoid `<h4>` inside `<p>`

## Testing
- `npm run check-unlocalized-strings` *(fails: cannot find module `@babel/parser`)*

------
https://chatgpt.com/codex/tasks/task_b_6854705e8fb8832889505db18eb9b682